### PR TITLE
Add ability to use its own config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ pip install gri
 You can just run `gri`, or `python -m gri` in order to get a list of your
 current reviews, aslo known as outgoing reviews.
 
-Currently the tool loads gerrit servers defined in [`~/.gertty.yaml`][1] but
-uses credentials from `~/.netrc` file.
+GRI uses a simple config file [`~/.config/gri/gri.yaml`][1] but when the file
+is missing, it will try to load servers from [`~/.gertty.yaml`][2] in case you
+have one.
 
 ```console
 $ gri --help
@@ -65,19 +66,20 @@ the missing change.
 
 ## Related tools
 
-* [git-review][3] is the git extension for working with gerrit, where I am also
+* [git-review][4] is the git extension for working with gerrit, where I am also
   one of the core contributors.
-* [GerTTY](https://github.com/openstack/gertty) is a very useful tui for gerrit
+* [gertty](https://opendev.org/ttygroup/gertty) is a very useful tui for gerrit
   which inspired me but which presents one essential design limitation: it does
   not work with multiple Gerrit servers.
-* [Gerrit-View](https://github.com/Gruntfuggly/gerrit-view) is a vscode plugin
-  that can be installed from [Visual Studio Marketplace][2].
+* [gerrit-view](https://github.com/Gruntfuggly/gerrit-view) is a vscode plugin
+  that can be installed from [Visual Studio Marketplace][3].
 
 ## Notes
 
 1. `gri` name comes from my attempt to find a short name that was starting
    with **g** (from git/gerrit) and preferably sounds like `cli`.
 
-[1]: https://github.com/openstack/gertty/tree/master/examples
-[2]: https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.gerrit-view
-[3]: https://docs.openstack.org/infra/git-review/
+[1]: https://github.com/pycontribs/gri/blob/master/test/gri.yaml
+[2]: https://opendev.org/ttygroup/gertty/src/branch/master/examples/minimal-gertty.yaml
+[3]: https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.gerrit-view
+[4]: https://docs.openstack.org/infra/git-review/

--- a/lib/gri/__main__.py
+++ b/lib/gri/__main__.py
@@ -17,7 +17,10 @@ from gri.gerrit import GerritServer
 from gri.review import Review
 
 term = bootstrap()
-CFG_FILE = "~/.gertty.yaml"
+
+# Respect XDG_CONFIG_HOME
+CFG_FILE = "~/.config/gri/gri.yaml"
+GERTTY_CFG_FILE = "~/.gertty.yaml"
 
 LOG = logging.getLogger(__package__)
 
@@ -29,13 +32,20 @@ class Config(dict):
 
     def load_config(self, config_file):
         self.config_file = config_file
-        _ = os.path.expanduser(config_file)
-        with open(_, "r") as stream:
-            try:
+        config_file_full = os.path.expanduser(config_file)
+        if not os.path.isfile(config_file_full):
+            LOG.warning(
+                "%s config file missing, attempting use of %s as fallback",
+                config_file_full,
+                GERTTY_CFG_FILE,
+            )
+            config_file_full = config_file_full = os.path.expanduser(GERTTY_CFG_FILE)
+        try:
+            with open(config_file_full, "r") as stream:
                 return yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                LOG.error(exc)
-                sys.exit(2)
+        except (FileNotFoundError, yaml.YAMLError) as exc:
+            LOG.error(exc)
+            sys.exit(2)
 
 
 # pylint: disable=too-few-public-methods

--- a/test/.gertty.yaml
+++ b/test/.gertty.yaml
@@ -1,5 +1,0 @@
-servers:
-  - name: gerrithub
-    url: https://review.gerrithub.io/
-    username: johndoe
-    password: CHANGEME

--- a/test/gri.yaml
+++ b/test/gri.yaml
@@ -1,0 +1,7 @@
+servers:
+  - name: gerrithub
+    url: https://review.gerrithub.io/
+
+# Usernames and passwords are loaded from ~/.netrc file
+# Keep in mind that gerrit password/token is obtained from its web interface
+# machine review.gerrithub.io login johndoe password ...


### PR DESCRIPTION
From now gri will try to load `~/.config/gri/gri.yaml` first and fallback to gertty config if this is missing.