### PR TITLE
add project based query for merged reviews

### DIFF
--- a/lib/gri/__main__.py
+++ b/lib/gri/__main__.py
@@ -330,6 +330,22 @@ def merged(ctx, age):
     """Merged in the last number of days"""
     ctx.obj.report(query=Query("merged", age=age), title=f"Merged Reviews ({age}d)")
 
+@cli.command()
+@click.pass_context
+@click.option(
+    "--project_name",
+    default="tripleo",
+    help="project alias in gerrit. This must be configured in gerrit config",
+)
+@click.option(
+    "--age",
+    default=1,
+    help="Number of days to look back, adds -age:NUM",
+)
+def project_merged(ctx, age, project_name):
+    """Merged by project in the last number of days"""
+    ctx.obj.report(query=Query("project_merged", age=age, project_name=project_name),
+                              title=f"Project Merged Reviews ({age}d)")
 
 # @cli.command()
 # @click.pass_context

--- a/lib/gri/abc.py
+++ b/lib/gri/abc.py
@@ -11,6 +11,7 @@ from gri.label import Label
 class Query:
     name: str
     age: int = 0
+    project_name: str = ""
 
 
 class Server(ABC):  # pylint: disable=too-few-public-methods

--- a/lib/gri/gerrit.py
+++ b/lib/gri/gerrit.py
@@ -111,6 +111,8 @@ class GerritServer(Server):
             return "status:open owner:self has:draft OR draftby:self"
         if query.name == "merged":
             return f"status:merged -age:{query.age}d owner:{self.ctx.obj.user}"
+        if query.name == "project_merged":
+            return f"{query.project_name} status:merged -age:{query.age}d"
 
         raise NotImplementedError(
             f"{query.name} query not implemented by {self.__class__}"


### PR DESCRIPTION
Although it's not often used in gerrit. It is possible
to query a configured project.  A gerrit project is a set
of gerrit repos with a given name, this is a server side
config.

In my particular use case it is very helpful to see what
reviews have merged in $x days for the "tripleo" project